### PR TITLE
New way of handling now_playing events

### DIFF
--- a/src/scrobble.h
+++ b/src/scrobble.h
@@ -243,11 +243,22 @@ static bool scrobble_is_valid(const struct scrobble *s)
 }
 
 bool now_playing_is_valid(const struct scrobble *m/*, const time_t current_time, const time_t last_playing_time*/) {
+#if 0
+    _trace("Checking playtime: %u - %u", m->play_time, (m->length / 2));
+    _trace("Checking scrobble:\n" \
+            "title: %s\n" \
+            "artist: %s\n" \
+            "album: %s\n" \
+            "length: %u\n" \
+            "play_time: %u\n", m->title, m->artist, m->album, m->length, m->play_time);
+#endif
     return (
         NULL != m &&
         NULL != m->title && strlen(m->title) > 0 &&
-        NULL != m->artist && strlen(m->artist) > 0 &&
-        NULL != m->album && strlen(m->album) > 0 &&
+        (
+            (NULL != m->artist && strlen(m->artist) > 0) ||
+            (NULL != m->album && strlen(m->album) > 0)
+        ) &&
 //        last_playing_time > 0 &&
 //        difftime(current_time, last_playing_time) >= LASTFM_NOW_PLAYING_DELAY &&
         m->length > 0

--- a/src/scrobble.h
+++ b/src/scrobble.h
@@ -127,8 +127,9 @@ static void scrobbler_free(struct scrobbler *s)
 static void mpris_player_free(struct mpris_player *player)
 {
     _trace("mem::freeing_player(%p)::queue_length:%u", player, player->queue_length);
-    for (unsigned i = 0; i < player->queue_length; i++) {
+    for (size_t i = 0; i < player->queue_length; i++) {
         mpris_properties_free(player->queue[i]);
+        player->queue[i] = NULL;
     }
     if (NULL != player->mpris_name) { free(player->mpris_name); }
     if (NULL != player->properties) { mpris_properties_free(player->properties); }
@@ -177,7 +178,6 @@ static void mpris_player_init(struct mpris_player *player, DBusConnection *conn)
     player->mpris_name = NULL;
     player->changed = calloc(1, sizeof(struct mpris_event));
 
-
     if (NULL != conn) {
         player->properties = mpris_properties_new();
 
@@ -201,6 +201,7 @@ static void state_init(struct state *s)
 
     s->events = events_new();
     s->dbus = dbus_connection_init(s);
+
     mpris_player_init(s->player, s->dbus->conn);
     state_loaded_properties(s, s->player->properties, s->player->changed);
 

--- a/src/sdbus.h
+++ b/src/sdbus.h
@@ -808,7 +808,6 @@ static void dispatch(int fd, short ev, void *data)
     }
 }
 
-void mpris_event_clear(struct mpris_event*);
 static void handle_dispatch_status(DBusConnection *conn, DBusDispatchStatus status, void *data)
 {
     struct state *state = data;
@@ -823,7 +822,6 @@ static void handle_dispatch_status(DBusConnection *conn, DBusDispatchStatus stat
     if (status == DBUS_DISPATCH_COMPLETE) {
         _trace("dbus::new_dispatch_status(%p): %s", (void*)conn, "COMPLETE");
 
-        mpris_event_clear(state->player->changed);
         state_loaded_properties(state, state->player->properties, state->player->changed);
     }
     if (status == DBUS_DISPATCH_NEED_MEMORY) {

--- a/src/sdbus.h
+++ b/src/sdbus.h
@@ -457,7 +457,7 @@ bool ping_player(DBusConnection* conn, const char* destination)
     char* method = DBUS_METHOD_PING;
     char* path = MPRIS_PLAYER_PATH;
 
-    msg = dbus_message_new_method_call("org.mpris.MediaPlayer21", path, interface, method);
+    msg = dbus_message_new_method_call("org.mpris.MediaPlayer2", path, interface, method);
     if (NULL == msg) { return available; }
 
    // send message and get a handle for a reply
@@ -916,7 +916,7 @@ static DBusHandlerResult add_filter(DBusConnection *conn, DBusMessage *message, 
                dbus_message_get_type(message) == DBUS_MESSAGE_TYPE_ERROR ?
                dbus_message_get_error_name(message) : "",
                conn
-               );
+        );
     }
 
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;

--- a/src/sevents.h
+++ b/src/sevents.h
@@ -268,6 +268,7 @@ void state_loaded_properties(struct state *state, mpris_properties *properties, 
         // trigger position event
     }
     scrobble_free(scrobble);
+    mpris_event_clear(state->player->changed);
 }
 
 #if 0

--- a/src/sevents.h
+++ b/src/sevents.h
@@ -191,6 +191,9 @@ static void add_event_scrobble(struct state *state)
 {
     struct timeval scrobble_tv;
     struct events *ev = state->events;
+    if (NULL == state->player) { return; }
+    if (NULL == state->player->current) { return; }
+    if (NULL == state->player->current->metadata) { return; }
     //if (NULL != ev->scrobble) { remove_event_scrobble(state); }
 
     ev->scrobble = malloc(sizeof(struct event));
@@ -199,7 +202,7 @@ static void add_event_scrobble(struct state *state)
     event_assign(ev->scrobble, ev->base, -1, EV_PERSIST, send_scrobble, state);
     evutil_timerclear(&scrobble_tv);
 
-    scrobble_tv.tv_sec = state->player->current->metadata->length / 2;
+    scrobble_tv.tv_sec = state->player->current->metadata->length / 2000000;
     _trace("events::add_event(%p):scrobble in %2.3f seconds", ev->scrobble, (double)scrobble_tv.tv_sec);
     event_add(ev->scrobble, &scrobble_tv);
 }

--- a/src/smpris.h
+++ b/src/smpris.h
@@ -8,7 +8,6 @@
 #define MPRIS_PLAYBACK_STATUS_PAUSED   "Paused"
 #define MPRIS_PLAYBACK_STATUS_STOPPED  "Stopped"
 
-#if 0
 static void mpris_metadata_zero(mpris_metadata* metadata)
 {
     metadata->track_number = 0;
@@ -28,7 +27,6 @@ static void mpris_metadata_zero(mpris_metadata* metadata)
     if (NULL != metadata->track_id) { free(metadata->track_id); metadata->track_id = NULL; }
     _trace("mem::zeroed_metadata(%p)", metadata);
 }
-#endif
 
 static void mpris_metadata_init(mpris_metadata* metadata)
 {
@@ -116,8 +114,7 @@ static void mpris_metadata_free(mpris_metadata *metadata)
     free(metadata);
 }
 
-#if 0
-static void mpris_properties_zero(mpris_properties *properties, bool metadata_too)
+void mpris_properties_zero(mpris_properties *properties, bool metadata_too)
 {
     properties->volume = 0;
     properties->position = 0;
@@ -134,7 +131,6 @@ static void mpris_properties_zero(mpris_properties *properties, bool metadata_to
     if (metadata_too) { mpris_metadata_zero(properties->metadata); }
     _trace("mem::zeroed_properties(%p)", properties);
 }
-#endif
 
 static void mpris_properties_init(mpris_properties *properties)
 {
@@ -185,7 +181,6 @@ void mpris_properties_free(mpris_properties *properties)
     free(properties);
 }
 
-#if 0
 static void mpris_metadata_copy(mpris_metadata  *d, const mpris_metadata *s)
 {
     if (NULL == s) { return; }
@@ -230,7 +225,6 @@ static void mpris_properties_copy(mpris_properties *d, const mpris_properties* s
     d->can_seek = s->can_seek;
     d->shuffle = s->shuffle;
 }
-#endif
 
 static bool mpris_properties_is_playing(const mpris_properties *s)
 {

--- a/src/structs.h
+++ b/src/structs.h
@@ -83,24 +83,14 @@ typedef struct mpris_properties {
 
 struct events {
     struct event_base *base;
-    union {
-        struct event *signal_events[3];
-        struct {
-            struct event *sigint;
-            struct event *sigterm;
-            struct event *sighup;
-        };
-    };
-    union {
-        struct event *events[4];
-        struct {
-            struct event *dispatch;
-            struct event *scrobble;
-            struct event *ping;
-            size_t now_playing_count;
-            struct event *now_playing[MAX_NOW_PLAYING_EVENTS];
-        };
-    };
+    struct event *sigint;
+    struct event *sigterm;
+    struct event *sighup;
+    struct event *dispatch;
+    struct event *scrobble;
+    struct event *ping;
+    size_t now_playing_count;
+    struct event *now_playing[MAX_NOW_PLAYING_EVENTS];
 };
 
 struct scrobble {

--- a/src/structs.h
+++ b/src/structs.h
@@ -30,6 +30,8 @@
 
 #define MAX_API_COUNT 10
 
+#define MAX_NOW_PLAYING_EVENTS      10
+
 typedef enum api_type {
     lastfm,
     librefm,
@@ -95,10 +97,11 @@ struct events {
     union {
         struct event *events[4];
         struct {
-            struct event *now_playing;
             struct event *dispatch;
             struct event *scrobble;
             struct event *ping;
+            size_t now_playing_count;
+            struct event *now_playing[MAX_NOW_PLAYING_EVENTS];
         };
     };
 };

--- a/src/structs.h
+++ b/src/structs.h
@@ -136,15 +136,18 @@ typedef struct dbus {
     DBusTimeout *timeout;
 } dbus;
 
+//typedef union queue {
+//} queue;
+
 struct mpris_player {
     char *mpris_name;
     mpris_properties *properties;
     union {
         struct {
-            struct scrobble *current;
-            struct scrobble *previous;
+            struct mpris_properties *current;
+            struct mpris_properties *previous;
         };
-        struct scrobble *queue[QUEUE_MAX_LENGTH];
+        struct mpris_properties *queue[QUEUE_MAX_LENGTH];
     };
     size_t queue_length;
     struct mpris_event *changed;

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,3 +1,3 @@
-`#'ifndev VERSION_HASH
+`#'ifndef VERSION_HASH
 `#'define VERSION_HASH "GIT_VERSION"
 `#'endif


### PR DESCRIPTION
Instead of adding the new event every after we process one, we calculate and add them all once when mpris properties change.