### PR TITLE
Change dir variables for RPM build environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ SIGNONSOURCES = src/signon.c
 UNIT_NAME=$(DAEMONNAME).service
 
 DESTDIR ?= /
-INSTALL_PREFIX ?= usr/local/
-BINDIR ?= bin
-USERUNITDIR ?= lib/systemd/user
+INSTALL_PREFIX ?= /usr/
+BINDIR ?= bin/
+USERUNITDIR ?= /lib64/systemd/user
 BUSNAME=org.mpris.scrobbler
 
 ifeq ($(findstring cc,$(CC)),cc)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ UNIT_NAME=$(DAEMONNAME).service
 DESTDIR ?= /
 INSTALL_PREFIX ?= /usr/
 BINDIR ?= bin/
-USERUNITDIR ?= /lib64/systemd/user
+USERUNITDIR ?= /lib/systemd/user
 BUSNAME=org.mpris.scrobbler
 
 ifeq ($(findstring cc,$(CC)),cc)


### PR DESCRIPTION
# Summary

While packaging mpris-scrobbler [into an RPM](https://github.com/jflory7/rpm-specs/blob/add/mpris-scrobbler/rpmbuild/SPECS/mpris-scrobbler.spec), there were some build failures because of the directory paths; this PR corrects them so mpris-scrobbler will build successfully in an RPM build environment.

# Explanation

1. `INSTALL_PREFIX`: Since it's a system-wide installation, use `/usr/`
2. `BINDIR`: Needs the trailing slash for RPM to find the binaries
3. `USERUNITDIR`: Fedora defaults to `lib64` for 64-bit systems – changing this makes it build successfully

If you feel 32-bit is _really_ necessary, we could probably find an alternate for no. 3. However, I think 64-bit systems are going to be more common than 32-bit, so I thought this was a safe change.