### PR TITLE
Submit on reload

### DIFF
--- a/doc/mpris-scrobbler.1.scd
+++ b/doc/mpris-scrobbler.1.scd
@@ -56,7 +56,7 @@ It can interact with any media-player that conforms to the *MPRIS D-Bus Interfac
 	The *mpris-scrobbler* daemon treats this signal the same as *SIGTERM*.
 
 *SIGHUP*
-	Reloads the credentials file.
+	Reloads the credentials file[3], then reloads the current playing track if possible and submits it to the loaded services.
 
 # ENVIRONMENT
 
@@ -71,6 +71,8 @@ _$XDG\_CONFIG\_HOME_, _$XDG\_DATA\_HOME_, _$XDG\_CACHE\_HOME_, _$XDG\_RUNTIME\_D
 
 2.  *XDG Base Directory specification*
 	http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+3.  *mpris-scrobbler-credentials*(5)
 
 # SEE ALSO
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -60,14 +60,9 @@ int main (int argc, char *argv[])
         goto _free_state;
     }
 
-    struct sighandler_payload *sig_data = calloc(1, sizeof(struct sighandler_payload));
-    if (NULL == sig_data) {
-        goto _free_sig_data;
-    }
-
-    sig_data->config = config;
-    if (!state_init(state, sig_data)) {
-        goto _free_sig_data;
+    if (!state_init(state, config)) {
+        _error("main::unable to initialize");
+        goto _free_state;
     }
 
     char *full_pid_path = get_pid_file(config);
@@ -86,10 +81,6 @@ _exit:
         _trace("main::cleanup_pid: %s", full_pid_path);
         cleanup_pid(full_pid_path);
         free(full_pid_path);
-    }
-_free_sig_data:
-    if (NULL != sig_data) {
-        free(sig_data);
     }
 _free_state:
     if (NULL != state) {

--- a/src/scrobble.h
+++ b/src/scrobble.h
@@ -229,7 +229,7 @@ static void mpris_player_init(struct mpris_player *player, DBusConnection *conn)
 
 struct scrobbler *scrobbler_new(void);
 struct events *events_new(void);
-void events_init(struct events*, struct sighandler_payload*);
+void events_init(struct state*);
 void scrobbler_init(struct scrobbler*, struct configuration*, struct events*);
 bool state_init(struct state *s, struct configuration *config)
 {
@@ -242,23 +242,19 @@ bool state_init(struct state *s, struct configuration *config)
     s->player = mpris_player_new();
     if (NULL == s->player) { return false; }
 
-    struct sighandler_payload *sig_data = calloc(1, sizeof(struct sighandler_payload));
-    if (NULL == sig_data) { return false; }
-
-    sig_data->config = config;
+    s->config = config;
 
     s->events = events_new();
     if (NULL == s->events) { return false; }
 
-    events_init(s->events, sig_data);
+    events_init(s);
 
     s->dbus = dbus_connection_init(s);
     if (NULL == s->dbus) { return false; }
 
-    scrobbler_init(s->scrobbler, sig_data->config, s->events);
+    scrobbler_init(s->scrobbler, s->config, s->events);
 
     mpris_player_init(s->player, s->dbus->conn);
-    sig_data->state = s;
 
     _trace2("mem::inited_state(%p)", s);
 
@@ -269,7 +265,7 @@ bool state_init(struct state *s, struct configuration *config)
 
 struct state *state_new(void)
 {
-    struct state *result = malloc(sizeof(struct state));
+    struct state *result = calloc(1, sizeof(struct state));
     return result;
 }
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -196,6 +196,7 @@ struct state {
     struct dbus *dbus;
     struct mpris_player *player;
     struct events *events;
+    struct configuration *config;
 
 };
 
@@ -228,12 +229,6 @@ struct parsed_arguments {
     enum binary_type binary;
     enum log_levels log_level;
     enum api_type service;
-};
-
-struct sighandler_payload {
-    struct event_base *event_base;
-    struct configuration *config;
-    struct state *state;
 };
 
 struct now_playing_payload {

--- a/src/structs.h
+++ b/src/structs.h
@@ -233,6 +233,7 @@ struct parsed_arguments {
 struct sighandler_payload {
     struct event_base *event_base;
     struct configuration *config;
+    struct state *state;
 };
 
 struct now_playing_payload {

--- a/src/utils.h
+++ b/src/utils.h
@@ -166,12 +166,13 @@ const char *get_api_type_label(enum api_type end_point)
     return NULL;
 }
 
+void resend_now_playing (struct state *);
 bool load_configuration(struct configuration*, const char*);
 void sighandler(evutil_socket_t signum, short events, void *user_data)
 {
     if (events) { events = 0; }
-    struct sighandler_payload *s = user_data;
-    struct event_base *eb = s->event_base;
+    struct state *s = user_data;
+    struct event_base *eb = s->events->base;
 
     const char *signal_name = "UNKNOWN";
     switch (signum) {
@@ -190,6 +191,7 @@ void sighandler(evutil_socket_t signum, short events, void *user_data)
 
     if (signum == SIGHUP) {
         load_configuration(s->config, APPLICATION_NAME);
+        resend_now_playing(s);
     }
     if (signum == SIGINT || signum == SIGTERM) {
         event_base_loopexit(eb, NULL);


### PR DESCRIPTION
Not the best way of solving this, but it should work for now. 

No new memory leaks because of it.

The only problem is that we removed the streamlined sighandler_payload struct that was passed to the signal handler function and was replaced with passing the full state instance. Not ideal.