### PR TITLE
systemd: Add automatic restart to example service

### DIFF
--- a/units/systemd-user.service.in
+++ b/units/systemd-user.service.in
@@ -9,6 +9,8 @@ Environment="XDG_DATA_HOME=%h/.local/share"
 ExecStart = BINPATH`'DAEMONNAME -vv
 ExecReload = /bin/kill -HUP $MAINPID
 CPUQuota=1%
+Restart=Always
+RestartSec=30
 
 [Install]
 WantedBy=default.target

--- a/units/systemd-user.service.in
+++ b/units/systemd-user.service.in
@@ -8,9 +8,9 @@ Type = simple
 Environment="XDG_DATA_HOME=%h/.local/share"
 ExecStart = BINPATH`'DAEMONNAME -vv
 ExecReload = /bin/kill -HUP $MAINPID
-CPUQuota=1%
-Restart=Always
-RestartSec=30
+CPUQuota = 1%
+Restart = on-failure
+RestartSec = 30
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This commit adds a `Restart` and `RestartSec` parameter to the systemd
service file. If the process exits for whatever reason, systemd will
automatically restart the service after the `RestartSec` interval in
seconds.

**References**:

* https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
* https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=