### PR TITLE
Additional Metadata for ListenBrainz

### DIFF
--- a/src/listenbrainz_api.h
+++ b/src/listenbrainz_api.h
@@ -35,6 +35,7 @@
 #define API_SUBMITTER_NODE_NAME                   "submission_client"
 #define API_SUBMITTER_VERS_NODE_NAME              "submission_client_version"
 #define API_URI_NODE_NAME                         "origin_url"
+#define API_PLAYER_NODE_NAME                      "media_player"
 
 // we e.g. don't want to submit file:// URIs to LB
 #define API_URI_WHITELIST_0             "http://"
@@ -157,6 +158,7 @@ static struct http_request *listenbrainz_api_build_request_now_playing(const str
     json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_double(track->length));
     json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(APPLICATION_NAME));
     json_object_object_add(additional_info, API_SUBMITTER_VERS_NODE_NAME, json_object_new_string(VERSION_HASH));
+    json_object_object_add(additional_info, API_PLAYER_NODE_NAME, json_object_new_string(track->player_name));
     if (strlen(mb_track_id) > 0) {
         json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
     }
@@ -266,6 +268,7 @@ static struct http_request *listenbrainz_api_build_request_scrobble(const struct
         json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_double(track->length));
         json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(APPLICATION_NAME));
         json_object_object_add(additional_info, API_SUBMITTER_VERS_NODE_NAME, json_object_new_string(VERSION_HASH));
+        json_object_object_add(additional_info, API_PLAYER_NODE_NAME, json_object_new_string(track->player_name));
         if (strlen(mb_track_id) > 0) {
             json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
         }

--- a/src/listenbrainz_api.h
+++ b/src/listenbrainz_api.h
@@ -34,6 +34,11 @@
 #define API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME      "artist_mbids"
 #define API_MUSICBRAINZ_ALBUM_ID_NODE_NAME        "release_mbid"
 #define API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME      "spotify_id"
+#define API_URI_NODE_NAME                         "origin_url"
+
+// we e.g. don't want to submit file:// URIs to LB
+#define API_URI_WHITELIST_0             "http://"
+#define API_URI_WHITELIST_1             "https://"
 
 #define API_CODE_NODE_NAME              "code"
 #define API_ERROR_NODE_NAME             "error"
@@ -166,6 +171,13 @@ static struct http_request *listenbrainz_api_build_request_now_playing(const str
     if (strlen(track->mb_spotify_id) > 0) {
         json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
     }
+    if (
+        strlen(track->url) > 0
+        && (strncmp(track->url, API_URI_WHITELIST_0, strlen(API_URI_WHITELIST_0)) == 0
+        || strncmp(track->url, API_URI_WHITELIST_1, strlen(API_URI_WHITELIST_1)) == 0)
+    ) {
+        json_object_object_add(additional_info, API_URI_NODE_NAME, json_object_new_string(track->url));
+    }
     json_object_object_add(metadata, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
 
     json_object_object_add(payload_elem, API_METADATA_NODE_NAME, metadata);
@@ -267,6 +279,13 @@ static struct http_request *listenbrainz_api_build_request_scrobble(const struct
         }
         if (strlen(track->mb_spotify_id) > 0) {
             json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
+        }
+        if (
+            strlen(track->url) > 0
+            && (strncmp(track->url, API_URI_WHITELIST_0, strlen(API_URI_WHITELIST_0)) == 0
+            || strncmp(track->url, API_URI_WHITELIST_1, strlen(API_URI_WHITELIST_1)) == 0)
+        ) {
+            json_object_object_add(additional_info, API_URI_NODE_NAME, json_object_new_string(track->url));
         }
         json_object_object_add(metadata, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
 

--- a/src/listenbrainz_api.h
+++ b/src/listenbrainz_api.h
@@ -155,7 +155,7 @@ static struct http_request *listenbrainz_api_build_request_now_playing(const str
     const char *mb_album_id = (char*)track->mb_album_id[0];
 
     json_object *additional_info = json_object_new_object();
-    json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_double(track->length));
+    json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_int((int)track->length));
     json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(APPLICATION_NAME));
     json_object_object_add(additional_info, API_SUBMITTER_VERS_NODE_NAME, json_object_new_string(VERSION_HASH));
     json_object_object_add(additional_info, API_PLAYER_NODE_NAME, json_object_new_string(track->player_name));
@@ -265,7 +265,7 @@ static struct http_request *listenbrainz_api_build_request_scrobble(const struct
         const char *mb_album_id = (char*)track->mb_album_id[0];
 
         json_object *additional_info = json_object_new_object();
-        json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_double(track->length));
+        json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_int((int)track->length));
         json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(APPLICATION_NAME));
         json_object_object_add(additional_info, API_SUBMITTER_VERS_NODE_NAME, json_object_new_string(VERSION_HASH));
         json_object_object_add(additional_info, API_PLAYER_NODE_NAME, json_object_new_string(track->player_name));

--- a/src/listenbrainz_api.h
+++ b/src/listenbrainz_api.h
@@ -249,25 +249,26 @@ static struct http_request *listenbrainz_api_build_request_scrobble(const struct
         const char *mb_track_id = (char*)track->mb_track_id[0];
         const char *mb_artist_id = (char*)track->mb_artist_id[0];
         const char *mb_album_id = (char*)track->mb_album_id[0];
-        if ( (strlen(mb_track_id) > 0)|| (strlen(mb_artist_id) > 0) || (strlen(mb_album_id) > 0) || (strlen(track->mb_spotify_id) > 0)) {
-            json_object *additional_info = json_object_new_object();
-            if (strlen(mb_track_id) > 0) {
-                json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
-            }
-            if (strlen(mb_artist_id) > 0) {
-                json_object *artists_ids = json_object_new_array();
-                json_object_array_add(artists_ids, json_object_new_string(mb_artist_id));
-                json_object_object_add(additional_info, API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME, artists_ids);
-            }
-            if (strlen(mb_album_id) > 0) {
-                json_object_object_add(additional_info, API_MUSICBRAINZ_ALBUM_ID_NODE_NAME, json_object_new_string(mb_album_id));
-            }
-            if (strlen(track->mb_spotify_id) > 0) {
-                json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
-            }
 
-            json_object_object_add(metadata, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
+        json_object *additional_info = json_object_new_object();
+        json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_double(track->length));
+        json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(APPLICATION_NAME));
+        json_object_object_add(additional_info, API_SUBMITTER_VERS_NODE_NAME, json_object_new_string(VERSION_HASH));
+        if (strlen(mb_track_id) > 0) {
+            json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
         }
+        if (strlen(mb_artist_id) > 0) {
+            json_object *artists_ids = json_object_new_array();
+            json_object_array_add(artists_ids, json_object_new_string(mb_artist_id));
+            json_object_object_add(additional_info, API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME, artists_ids);
+        }
+        if (strlen(mb_album_id) > 0) {
+            json_object_object_add(additional_info, API_MUSICBRAINZ_ALBUM_ID_NODE_NAME, json_object_new_string(mb_album_id));
+        }
+        if (strlen(track->mb_spotify_id) > 0) {
+            json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
+        }
+        json_object_object_add(metadata, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
 
         json_object_object_add(payload_elem, API_LISTENED_AT_NODE_NAME, json_object_new_int64(track->start_time));
         json_object_object_add(payload_elem, API_METADATA_NODE_NAME, metadata);

--- a/src/listenbrainz_api.h
+++ b/src/listenbrainz_api.h
@@ -8,11 +8,6 @@
 #include "credentials_listenbrainz.h"
 #endif
 
-#include "version.h"
-// #ifndef MPRIS_SCROBBLER_CONFIGURATION_H
-// #include "configuration.h"
-// #endif
-
 #define API_LISTEN_TYPE_NOW_PLAYING     "playing_now"
 #define API_LISTEN_TYPE_SINGLE          "single"
 #define API_LISTEN_TYPE_IMPORT          "import"
@@ -33,13 +28,13 @@
 #define API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME      "spotify_id"
 #define API_DURATION_NODE_NAME                    "duration"
 #define API_SUBMITTER_NODE_NAME                   "submission_client"
-#define API_SUBMITTER_VERS_NODE_NAME              "submission_client_version"
+#define API_SUBMITTER_VERSION_NODE_NAME           "submission_client_version"
 #define API_URI_NODE_NAME                         "origin_url"
 #define API_PLAYER_NODE_NAME                      "media_player"
 
 // we e.g. don't want to submit file:// URIs to LB
-#define API_URI_WHITELIST_0             "http://"
-#define API_URI_WHITELIST_1             "https://"
+#define API_PROTO_WHITELIST_HTTP        "http://"
+#define API_PROTO_WHITELIST_HTTPS       "https://"
 
 #define API_CODE_NODE_NAME              "code"
 #define API_ERROR_NODE_NAME             "error"
@@ -104,6 +99,41 @@ static http_request *build_generic_request()
 }
 #endif
 
+static void listenbrainz_api_append_additional_info(json_object* root,const struct scrobble *track){
+    const char *mb_track_id = (char*)track->mb_track_id[0];
+    const char *mb_artist_id = (char*)track->mb_artist_id[0];
+    const char *mb_album_id = (char*)track->mb_album_id[0];
+
+    json_object *additional_info = json_object_new_object();
+    json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_int((int)track->length));
+    json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(get_application_name()));
+    json_object_object_add(additional_info, API_SUBMITTER_VERSION_NODE_NAME, json_object_new_string(get_version()));
+    json_object_object_add(additional_info, API_PLAYER_NODE_NAME, json_object_new_string(track->player_name));
+    if (strlen(mb_track_id) > 0) {
+        json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
+    }
+    if (strlen(mb_artist_id) > 0) {
+        json_object *artists_ids = json_object_new_array();
+        json_object_array_add(artists_ids, json_object_new_string(mb_artist_id));
+        json_object_object_add(additional_info, API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME, artists_ids);
+    }
+    if (strlen(mb_album_id) > 0) {
+        json_object_object_add(additional_info, API_MUSICBRAINZ_ALBUM_ID_NODE_NAME, json_object_new_string(mb_album_id));
+    }
+    if (strlen(track->mb_spotify_id) > 0) {
+        json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
+    }
+    if (
+        strlen(track->url) > 0
+        && (strncmp(track->url, API_PROTO_WHITELIST_HTTP, strlen(API_PROTO_WHITELIST_HTTP)) == 0
+        || strncmp(track->url, API_PROTO_WHITELIST_HTTPS, strlen(API_PROTO_WHITELIST_HTTPS)) == 0)
+    ) {
+        json_object_object_add(additional_info, API_URI_NODE_NAME, json_object_new_string(track->url));
+    }
+
+    json_object_object_add(root, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
+}
+
 struct http_header *http_authorization_header_new (const char*);
 struct http_header *http_content_type_header_new (void);
 static struct http_request *listenbrainz_api_build_request_now_playing(const struct scrobble *tracks[], const unsigned track_count, const struct api_credentials *auth)
@@ -150,37 +180,7 @@ static struct http_request *listenbrainz_api_build_request_now_playing(const str
     }
     json_object_object_add(metadata, API_TRACK_NAME_NODE_NAME, json_object_new_string(track->title));
 
-    const char *mb_track_id = (char*)track->mb_track_id[0];
-    const char *mb_artist_id = (char*)track->mb_artist_id[0];
-    const char *mb_album_id = (char*)track->mb_album_id[0];
-
-    json_object *additional_info = json_object_new_object();
-    json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_int((int)track->length));
-    json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(APPLICATION_NAME));
-    json_object_object_add(additional_info, API_SUBMITTER_VERS_NODE_NAME, json_object_new_string(VERSION_HASH));
-    json_object_object_add(additional_info, API_PLAYER_NODE_NAME, json_object_new_string(track->player_name));
-    if (strlen(mb_track_id) > 0) {
-        json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
-    }
-    if (strlen(mb_artist_id) > 0) {
-        json_object *artists_ids = json_object_new_array();
-        json_object_array_add(artists_ids, json_object_new_string(mb_artist_id));
-        json_object_object_add(additional_info, API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME, artists_ids);
-    }
-    if (strlen(mb_album_id) > 0) {
-        json_object_object_add(additional_info, API_MUSICBRAINZ_ALBUM_ID_NODE_NAME, json_object_new_string(mb_album_id));
-    }
-    if (strlen(track->mb_spotify_id) > 0) {
-        json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
-    }
-    if (
-        strlen(track->url) > 0
-        && (strncmp(track->url, API_URI_WHITELIST_0, strlen(API_URI_WHITELIST_0)) == 0
-        || strncmp(track->url, API_URI_WHITELIST_1, strlen(API_URI_WHITELIST_1)) == 0)
-    ) {
-        json_object_object_add(additional_info, API_URI_NODE_NAME, json_object_new_string(track->url));
-    }
-    json_object_object_add(metadata, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
+    listenbrainz_api_append_additional_info(metadata, track);
 
     json_object_object_add(payload_elem, API_METADATA_NODE_NAME, metadata);
 
@@ -260,37 +260,8 @@ static struct http_request *listenbrainz_api_build_request_scrobble(const struct
         if (strlen(track->title) > 0) {
             json_object_object_add(metadata, API_TRACK_NAME_NODE_NAME, json_object_new_string(track->title));
         }
-        const char *mb_track_id = (char*)track->mb_track_id[0];
-        const char *mb_artist_id = (char*)track->mb_artist_id[0];
-        const char *mb_album_id = (char*)track->mb_album_id[0];
-
-        json_object *additional_info = json_object_new_object();
-        json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_int((int)track->length));
-        json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(APPLICATION_NAME));
-        json_object_object_add(additional_info, API_SUBMITTER_VERS_NODE_NAME, json_object_new_string(VERSION_HASH));
-        json_object_object_add(additional_info, API_PLAYER_NODE_NAME, json_object_new_string(track->player_name));
-        if (strlen(mb_track_id) > 0) {
-            json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
-        }
-        if (strlen(mb_artist_id) > 0) {
-            json_object *artists_ids = json_object_new_array();
-            json_object_array_add(artists_ids, json_object_new_string(mb_artist_id));
-            json_object_object_add(additional_info, API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME, artists_ids);
-        }
-        if (strlen(mb_album_id) > 0) {
-            json_object_object_add(additional_info, API_MUSICBRAINZ_ALBUM_ID_NODE_NAME, json_object_new_string(mb_album_id));
-        }
-        if (strlen(track->mb_spotify_id) > 0) {
-            json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
-        }
-        if (
-            strlen(track->url) > 0
-            && (strncmp(track->url, API_URI_WHITELIST_0, strlen(API_URI_WHITELIST_0)) == 0
-            || strncmp(track->url, API_URI_WHITELIST_1, strlen(API_URI_WHITELIST_1)) == 0)
-        ) {
-            json_object_object_add(additional_info, API_URI_NODE_NAME, json_object_new_string(track->url));
-        }
-        json_object_object_add(metadata, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
+        
+        listenbrainz_api_append_additional_info(metadata, track);
 
         json_object_object_add(payload_elem, API_LISTENED_AT_NODE_NAME, json_object_new_int64(track->start_time));
         json_object_object_add(payload_elem, API_METADATA_NODE_NAME, metadata);

--- a/src/listenbrainz_api.h
+++ b/src/listenbrainz_api.h
@@ -24,9 +24,6 @@
 #define API_ARTIST_NAME_NODE_NAME       "artist_name"
 #define API_TRACK_NAME_NODE_NAME        "track_name"
 #define API_ALBUM_NAME_NODE_NAME        "release_name"
-#define API_DURATION_NODE_NAME          "duration"
-#define API_SUBMITTER_NODE_NAME         "submission_client"
-#define API_SUBMITTER_VERS_NODE_NAME    "submission_client_version"
 
 #define API_ADDITIONAL_INFO_NODE_NAME             "additional_info"
 #define API_MUSICBRAINZ_TRACK_ID_NODE_NAME        "track_mbid"
@@ -34,6 +31,9 @@
 #define API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME      "artist_mbids"
 #define API_MUSICBRAINZ_ALBUM_ID_NODE_NAME        "release_mbid"
 #define API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME      "spotify_id"
+#define API_DURATION_NODE_NAME                    "duration"
+#define API_SUBMITTER_NODE_NAME                   "submission_client"
+#define API_SUBMITTER_VERS_NODE_NAME              "submission_client_version"
 #define API_URI_NODE_NAME                         "origin_url"
 
 // we e.g. don't want to submit file:// URIs to LB

--- a/src/listenbrainz_api.h
+++ b/src/listenbrainz_api.h
@@ -8,6 +8,11 @@
 #include "credentials_listenbrainz.h"
 #endif
 
+#include "version.h"
+// #ifndef MPRIS_SCROBBLER_CONFIGURATION_H
+// #include "configuration.h"
+// #endif
+
 #define API_LISTEN_TYPE_NOW_PLAYING     "playing_now"
 #define API_LISTEN_TYPE_SINGLE          "single"
 #define API_LISTEN_TYPE_IMPORT          "import"
@@ -19,6 +24,9 @@
 #define API_ARTIST_NAME_NODE_NAME       "artist_name"
 #define API_TRACK_NAME_NODE_NAME        "track_name"
 #define API_ALBUM_NAME_NODE_NAME        "release_name"
+#define API_DURATION_NODE_NAME          "duration"
+#define API_SUBMITTER_NODE_NAME         "submission_client"
+#define API_SUBMITTER_VERS_NODE_NAME    "submission_client_version"
 
 #define API_ADDITIONAL_INFO_NODE_NAME             "additional_info"
 #define API_MUSICBRAINZ_TRACK_ID_NODE_NAME        "track_mbid"
@@ -139,26 +147,27 @@ static struct http_request *listenbrainz_api_build_request_now_playing(const str
     const char *mb_track_id = (char*)track->mb_track_id[0];
     const char *mb_artist_id = (char*)track->mb_artist_id[0];
     const char *mb_album_id = (char*)track->mb_album_id[0];
-    if (strlen(mb_track_id) > 0 || strlen(mb_artist_id) > 0 || strlen(mb_album_id) > 0 || strlen(track->mb_spotify_id) > 0) {
-        json_object *additional_info = json_object_new_object();
 
-        if (strlen(mb_track_id) > 0) {
-            json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
-        }
-        if (strlen(mb_artist_id) > 0) {
-            json_object *artists_ids = json_object_new_array();
-            json_object_array_add(artists_ids, json_object_new_string(mb_artist_id));
-            json_object_object_add(additional_info, API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME, artists_ids);
-        }
-        if (strlen(mb_album_id) > 0) {
-            json_object_object_add(additional_info, API_MUSICBRAINZ_ALBUM_ID_NODE_NAME, json_object_new_string(mb_album_id));
-        }
-        if (strlen(track->mb_spotify_id) > 0) {
-            json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
-        }
-
-        json_object_object_add(metadata, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
+    json_object *additional_info = json_object_new_object();
+    json_object_object_add(additional_info, API_DURATION_NODE_NAME, json_object_new_double(track->length));
+    json_object_object_add(additional_info, API_SUBMITTER_NODE_NAME, json_object_new_string(APPLICATION_NAME));
+    json_object_object_add(additional_info, API_SUBMITTER_VERS_NODE_NAME, json_object_new_string(VERSION_HASH));
+    if (strlen(mb_track_id) > 0) {
+        json_object_object_add(additional_info, API_MUSICBRAINZ_RECORDING_ID_NODE_NAME, json_object_new_string(mb_track_id));
     }
+    if (strlen(mb_artist_id) > 0) {
+        json_object *artists_ids = json_object_new_array();
+        json_object_array_add(artists_ids, json_object_new_string(mb_artist_id));
+        json_object_object_add(additional_info, API_MUSICBRAINZ_ARTISTS_ID_NODE_NAME, artists_ids);
+    }
+    if (strlen(mb_album_id) > 0) {
+        json_object_object_add(additional_info, API_MUSICBRAINZ_ALBUM_ID_NODE_NAME, json_object_new_string(mb_album_id));
+    }
+    if (strlen(track->mb_spotify_id) > 0) {
+        json_object_object_add(additional_info, API_MUSICBRAINZ_SPOTIFY_ID_NODE_NAME, json_object_new_string(track->mb_spotify_id));
+    }
+    json_object_object_add(metadata, API_ADDITIONAL_INFO_NODE_NAME, additional_info);
+
     json_object_object_add(payload_elem, API_METADATA_NODE_NAME, metadata);
 
     json_object_array_add(payload, payload_elem);

--- a/src/scrobble.h
+++ b/src/scrobble.h
@@ -396,6 +396,7 @@ static bool load_scrobble(struct scrobble *d, const struct mpris_properties *p, 
     memcpy(d->album, p->metadata.album, sizeof(p->metadata.album));
     memcpy(d->artist, p->metadata.artist, sizeof(p->metadata.artist));
     memcpy(d->url, p->metadata.url, sizeof(p->metadata.url));
+    memcpy(d->player_name, p->player_name, sizeof(p->player_name));
 
     d->length = 0L;
     d->position = 0L;

--- a/src/scrobble.h
+++ b/src/scrobble.h
@@ -395,6 +395,7 @@ static bool load_scrobble(struct scrobble *d, const struct mpris_properties *p, 
     memcpy(d->title, p->metadata.title, sizeof(p->metadata.title));
     memcpy(d->album, p->metadata.album, sizeof(p->metadata.album));
     memcpy(d->artist, p->metadata.artist, sizeof(p->metadata.artist));
+    memcpy(d->url, p->metadata.url, sizeof(p->metadata.url));
 
     d->length = 0L;
     d->position = 0L;

--- a/src/sdbus.h
+++ b/src/sdbus.h
@@ -837,7 +837,7 @@ void load_player_mpris_properties(DBusConnection *conn, struct mpris_player *pla
         _error("mpris::loading_properties_error: %s", err.message);
         dbus_error_free(&err);
     }
-    strcpy(player->properties.player_name, player->name);
+    memcpy(player->properties.player_name, player->name, sizeof(player->properties.player_name));
 
     load_properties_if_changed(&player->properties, &properties, &changes);
     player->changed.loaded_state |= changes.loaded_state;

--- a/src/sdbus.h
+++ b/src/sdbus.h
@@ -837,6 +837,7 @@ void load_player_mpris_properties(DBusConnection *conn, struct mpris_player *pla
         _error("mpris::loading_properties_error: %s", err.message);
         dbus_error_free(&err);
     }
+    strcpy(player->properties.player_name, player->name);
 
     load_properties_if_changed(&player->properties, &properties, &changes);
     player->changed.loaded_state |= changes.loaded_state;

--- a/src/structs.h
+++ b/src/structs.h
@@ -138,9 +138,9 @@ struct mpris_properties {
     bool can_pause;
     bool can_seek;
     bool shuffle;
-    char player_name[MAX_PROPERTY_LENGTH];
-    char loop_status[MAX_PROPERTY_LENGTH];
-    char playback_status[MAX_PROPERTY_LENGTH];
+    char player_name[MAX_PROPERTY_LENGTH+1];
+    char loop_status[MAX_PROPERTY_LENGTH+1];
+    char playback_status[MAX_PROPERTY_LENGTH+1];
 };
 
 struct events {

--- a/src/structs.h
+++ b/src/structs.h
@@ -160,6 +160,7 @@ struct scrobble {
     bool scrobbled;
     unsigned short track_number;
 
+    char url[MAX_PROPERTY_LENGTH+1];
     char title[MAX_PROPERTY_LENGTH+1];
     char album[MAX_PROPERTY_LENGTH+1];
     char artist[MAX_PROPERTY_COUNT][MAX_PROPERTY_LENGTH+1];

--- a/src/structs.h
+++ b/src/structs.h
@@ -169,7 +169,7 @@ struct scrobble {
     char mb_album_id[MAX_PROPERTY_COUNT][MAX_PROPERTY_LENGTH+1];
     char mb_artist_id[MAX_PROPERTY_COUNT][MAX_PROPERTY_LENGTH+1];
     char mb_album_artist_id[MAX_PROPERTY_COUNT][MAX_PROPERTY_LENGTH+1];
-
+    char player_name[MAX_PROPERTY_LENGTH+1];
     char mb_spotify_id[MAX_PROPERTY_LENGTH+1]; // spotify id for listenbrainz
 };
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -311,4 +311,9 @@ static const char *get_version(void)
     return VERSION_HASH;
 }
 
+static const char *get_application_name(void)
+{
+    return APPLICATION_NAME;
+}
+
 #endif // MPRIS_SCROBBLER_UTILS_H


### PR DESCRIPTION
This PR closes #102.
It adds additional Metadata to the ListenBrainz scrobble.

Currently included:
- duration
- submission_client
- submission_client_version

When i have figured out how to properly populate other DBus properties to the scrobble struct, the following ones are planned:
- media_player
- (media_player_version if possible via DBus)
- origin_url if available (e.g. scrobbled from a browser)