### PR TITLE
Add support for custom endpoint base path

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -154,7 +154,7 @@ static size_t endpoint_get_host(char *result, const enum api_type type, const en
         if (NULL == base_path) {
             host_len = strlen(host);
         } else {
-            host_len = base_path - host;
+            host_len = (size_t)(base_path - host);
         }
     } else {
         switch (type) {


### PR DESCRIPTION
This PR adds the support for custom base path in endpoint URLs. It does this by introducing new field `base_path` in the `api_endpoint` struct, which gets concatenated with the canonical path when forming the final URL.

At this point, this is just a suggestion. Another option would be to not introduce a new field and do the parsing and concatenation in `endpoint_get_path`. Please let me know what you think.

I have successfully tested it on my Maloja server, which accepts scrobbles at `/apis/listenbrainz`.

Closes #111.